### PR TITLE
Fixed RESET functionality to emulate CPU behavior.

### DIFF
--- a/6502/6502Lib/src/private/m6502.cpp
+++ b/6502/6502Lib/src/private/m6502.cpp
@@ -1139,23 +1139,18 @@ m6502::Word m6502::CPU::AddrIndirectY_6( s32& Cycles, const Mem& memory )
 }
 
 
-m6502::Word m6502::CPU::LoadPrg( const Byte* Program, u32 NumBytes, Mem& memory ) const
+void m6502::CPU::LoadPrg( const Word LoadAddress, const Byte* Program, u32 NumBytes, Mem& memory ) const
 {
-	Word LoadAddress = 0;
 	if ( Program && NumBytes > 2 )
 	{
-		u32 At = 0;
-		const Word Lo = Program[At++];
-		const Word Hi = Program[At++] << 8;
-		LoadAddress = Lo | Hi;
-		for ( Word i = LoadAddress; i < LoadAddress+NumBytes-2; i++ )
+		for ( Word i = 0; i < NumBytes; i++ )
 		{
-			//TODO: mem copy?
-			memory[i] = Program[At++];
+			memory[LoadAddress + i] = Program[i];
 		}
 	}
-
-	return LoadAddress;
+	// Set up the RESET vector
+    memory[0xFFFC] = LoadAddress & 0xFF;
+    memory[0xFFFD] = LoadAddress >> 8;
 }
 
 void m6502::CPU::PrintStatus() const

--- a/6502/6502Lib/src/public/m6502.h
+++ b/6502/6502Lib/src/public/m6502.h
@@ -73,12 +73,8 @@ struct m6502::CPU
 
 	void Reset( Mem& memory )
 	{
-		Reset( 0xFFFC, memory );
-	}
-
-	void Reset( Word ResetVector, Mem& memory )
-	{
-		PC = ResetVector;
+	    Word StartAddress = memory[0xFFFC] | memory[0xFFFD] << 8;
+		PC = StartAddress;
 		SP = 0xFF;
 		Flag.C = Flag.Z = Flag.I = Flag.D = Flag.B = Flag.V = Flag.N = 0;
 		A = X = Y = 0;
@@ -418,8 +414,8 @@ struct m6502::CPU
 		Flag.N = (Register & NegativeFlagBit) > 0;
 	}
 
-	/** @return the address that the program was loading into, or 0 if no program */
-	Word LoadPrg( const Byte* Program, u32 NumBytes, Mem& memory ) const;
+	/** Load a Program into memory at the given LoadAddress and set up the RESET vector to that location. */
+	void LoadPrg( const Word LoadAddress, const Byte* Program, u32 NumBytes, Mem& memory ) const;
 
 	/** printf the registers, program counter etc */
 	void PrintStatus() const;

--- a/6502/6502Test/src/6502AND_EOR_ORA_Tests.cpp
+++ b/6502/6502Test/src/6502AND_EOR_ORA_Tests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0xFC;
+        mem[0xFFFD] = 0x2F;
 		cpu.Reset( mem );
 	}
 
@@ -41,13 +43,10 @@ public:
 		{
 		case ELogicalOp::And:
 			return A & B;
-			break;
 		case ELogicalOp::Or:
 			return A | B;
-			break;
 		case ELogicalOp::Eor:
 			return A ^ B;
-			break;
 		}
 
 		throw - 1; //invalid Logical Op
@@ -62,16 +61,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_IM;
+			mem[0x2FFC] = CPU::INS_AND_IM;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_IM;
+			mem[0x2FFC] = CPU::INS_ORA_IM;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_IM;
+			mem[0x2FFC] = CPU::INS_EOR_IM;
 			break;
 		}
-		mem[0xFFFD] = 0x84;
+		mem[0x2FFD] = 0x84;
 
 		//when:
 		CPU CPUCopy = cpu;
@@ -95,16 +94,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ZP;
+			mem[0x2FFC] = CPU::INS_AND_ZP;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ZP;
+			mem[0x2FFC] = CPU::INS_ORA_ZP;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ZP;
+			mem[0x2FFC] = CPU::INS_EOR_ZP;
 			break;
 		}
-		mem[0xFFFD] = 0x42;
+		mem[0x2FFD] = 0x42;
 		mem[0x0042] = 0x37;
 
 		//when:
@@ -130,16 +129,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ZPX;
+			mem[0x2FFC] = CPU::INS_AND_ZPX;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ZPX;
+			mem[0x2FFC] = CPU::INS_ORA_ZPX;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ZPX;
+			mem[0x2FFC] = CPU::INS_EOR_ZPX;
 			break;
 		}
-		mem[0xFFFD] = 0x42;
+		mem[0x2FFD] = 0x42;
 		mem[0x0047] = 0x37;
 		CPU CPUCopy = cpu;
 
@@ -165,17 +164,17 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ABS;
+			mem[0x2FFC] = CPU::INS_AND_ABS;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ABS;
+			mem[0x2FFC] = CPU::INS_ORA_ABS;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ABS;
+			mem[0x2FFC] = CPU::INS_EOR_ABS;
 			break;
 		}
-		mem[0xFFFD] = 0x80;
-		mem[0xFFFE] = 0x44;	//0x4480
+		mem[0x2FFD] = 0x80;
+		mem[0x2FFE] = 0x44;	//0x4480
 		mem[0x4480] = 0x37;
 		constexpr s32 EXPECTED_CYCLES = 4;
 		CPU CPUCopy = cpu;
@@ -203,17 +202,17 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ABSX;
+			mem[0x2FFC] = CPU::INS_AND_ABSX;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ABSX;
+			mem[0x2FFC] = CPU::INS_ORA_ABSX;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ABSX;
+			mem[0x2FFC] = CPU::INS_EOR_ABSX;
 			break;
 		}
-		mem[0xFFFD] = 0x80;
-		mem[0xFFFE] = 0x44;	//0x4480
+		mem[0x2FFD] = 0x80;
+		mem[0x2FFE] = 0x44;	//0x4480
 		mem[0x4481] = 0x37;
 		constexpr s32 EXPECTED_CYCLES = 4;
 		CPU CPUCopy = cpu;
@@ -241,17 +240,17 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ABSY;
+			mem[0x2FFC] = CPU::INS_AND_ABSY;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ABSY;
+			mem[0x2FFC] = CPU::INS_ORA_ABSY;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ABSY;
+			mem[0x2FFC] = CPU::INS_EOR_ABSY;
 			break;
 		}
-		mem[0xFFFD] = 0x80;
-		mem[0xFFFE] = 0x44;	//0x4480
+		mem[0x2FFD] = 0x80;
+		mem[0x2FFE] = 0x44;	//0x4480
 		mem[0x4481] = 0x37;
 		constexpr s32 EXPECTED_CYCLES = 4;
 		CPU CPUCopy = cpu;
@@ -278,17 +277,17 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ABSY;
+			mem[0x2FFC] = CPU::INS_AND_ABSY;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ABSY;
+			mem[0x2FFC] = CPU::INS_ORA_ABSY;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ABSY;
+			mem[0x2FFC] = CPU::INS_EOR_ABSY;
 			break;
 		}
-		mem[0xFFFD] = 0x02;
-		mem[0xFFFE] = 0x44;	//0x4402
+		mem[0x2FFD] = 0x02;
+		mem[0x2FFE] = 0x44;	//0x4402
 		mem[0x4501] = 0x37;	//0x4402+0xFF crosses page boundary!
 		constexpr s32 EXPECTED_CYCLES = 5;
 		CPU CPUCopy = cpu;
@@ -315,17 +314,17 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ABSX;
+			mem[0x2FFC] = CPU::INS_AND_ABSX;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ABSX;
+			mem[0x2FFC] = CPU::INS_ORA_ABSX;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ABSX;
+			mem[0x2FFC] = CPU::INS_EOR_ABSX;
 			break;
 		}
-		mem[0xFFFD] = 0x02;
-		mem[0xFFFE] = 0x44;	//0x4402
+		mem[0x2FFD] = 0x02;
+		mem[0x2FFE] = 0x44;	//0x4402
 		mem[0x4501] = 0x37;	//0x4402+0xFF crosses page boundary!
 		constexpr s32 EXPECTED_CYCLES = 5;
 		CPU CPUCopy = cpu;
@@ -353,16 +352,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_INDX;
+			mem[0x2FFC] = CPU::INS_AND_INDX;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_INDX;
+			mem[0x2FFC] = CPU::INS_ORA_INDX;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_INDX;
+			mem[0x2FFC] = CPU::INS_EOR_INDX;
 			break;
 		}
-		mem[0xFFFD] = 0x02;
+		mem[0x2FFD] = 0x02;
 		mem[0x0006] = 0x00;	//0x2 + 0x4
 		mem[0x0007] = 0x80;
 		mem[0x8000] = 0x37;
@@ -392,16 +391,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_INDY;
+			mem[0x2FFC] = CPU::INS_AND_INDY;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_INDY;
+			mem[0x2FFC] = CPU::INS_ORA_INDY;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_INDY;
+			mem[0x2FFC] = CPU::INS_EOR_INDY;
 			break;
 		}
-		mem[0xFFFD] = 0x02;
+		mem[0x2FFD] = 0x02;
 		mem[0x0002] = 0x00;
 		mem[0x0003] = 0x80;
 		mem[0x8004] = 0x37;	//0x8000 + 0x4
@@ -430,16 +429,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_INDY;
+			mem[0x2FFC] = CPU::INS_AND_INDY;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_INDY;
+			mem[0x2FFC] = CPU::INS_ORA_INDY;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_INDY;
+			mem[0x2FFC] = CPU::INS_EOR_INDY;
 			break;
 		}
-		mem[0xFFFD] = 0x02;
+		mem[0x2FFD] = 0x02;
 		mem[0x0002] = 0x02;
 		mem[0x0003] = 0x80;
 		mem[0x8101] = 0x37;	//0x8002 + 0xFF
@@ -469,16 +468,16 @@ public:
 		switch ( LogicalOp )
 		{
 		case ELogicalOp::And:
-			mem[0xFFFC] = CPU::INS_AND_ZPX;
+			mem[0x2FFC] = CPU::INS_AND_ZPX;
 			break;
 		case ELogicalOp::Or:
-			mem[0xFFFC] = CPU::INS_ORA_ZPX;
+			mem[0x2FFC] = CPU::INS_ORA_ZPX;
 			break;
 		case ELogicalOp::Eor:
-			mem[0xFFFC] = CPU::INS_EOR_ZPX;
+			mem[0x2FFC] = CPU::INS_EOR_ZPX;
 			break;
 		}
-		mem[0xFFFD] = 0x80;
+		mem[0x2FFD] = 0x80;
 		mem[0x007F] = 0x37;
 
 		//when:
@@ -537,8 +536,8 @@ TEST_F( M6502AndEorOraBitTests, TestLogicalOpEorImmediateCanAffectZeroFlag )
 	// given:
 	using namespace m6502;
 	cpu.A = 0xCC;
-	mem[0xFFFC] = CPU::INS_EOR_IM;
-	mem[0xFFFD] = cpu.A;
+	mem[0x2FFC] = CPU::INS_EOR_IM;
+	mem[0x2FFD] = cpu.A;
 	CPU CPUCopy = cpu;
 
 	//when:
@@ -705,10 +704,9 @@ TEST_F( M6502AndEorOraBitTests, TestBitZeroPage )
 	using namespace m6502;
 	cpu.Flag.V = cpu.Flag.N = false;
 	cpu.A = 0xCC;
-	mem[0xFFFC] = CPU::INS_BIT_ZP;	
-	mem[0xFFFD] = 0x42;
+	mem[0x2FFC] = CPU::INS_BIT_ZP;
+	mem[0x2FFD] = 0x42;
 	mem[0x0042] = 0xCC;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 3;
 
 	//when:
@@ -728,10 +726,9 @@ TEST_F( M6502AndEorOraBitTests, TestBitZeroPageResultZero )
 	using namespace m6502;
 	cpu.Flag.V = cpu.Flag.N = true;
 	cpu.A = 0xCC;
-	mem[0xFFFC] = CPU::INS_BIT_ZP;
-	mem[0xFFFD] = 0x42;
+	mem[0x2FFC] = CPU::INS_BIT_ZP;
+	mem[0x2FFD] = 0x42;
 	mem[0x0042] = 0x33;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 3;
 
 	//when:
@@ -751,10 +748,9 @@ TEST_F( M6502AndEorOraBitTests, TestBitZeroPageResultZeroBits6And7Zero )
 	using namespace m6502;
 	cpu.Flag.V = cpu.Flag.N = false;
 	cpu.A = 0x33;
-	mem[0xFFFC] = CPU::INS_BIT_ZP;
-	mem[0xFFFD] = 0x42;
+	mem[0x2FFC] = CPU::INS_BIT_ZP;
+	mem[0x2FFD] = 0x42;
 	mem[0x0042] = 0xCC;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 3;
 
 	//when:
@@ -774,8 +770,8 @@ TEST_F( M6502AndEorOraBitTests, TestBitZeroPageResultZeroBits6And7Mixed )
 	using namespace m6502;
 	cpu.Flag.V = false;
 	cpu.Flag.N = true;
-	mem[0xFFFC] = CPU::INS_BIT_ZP;
-	mem[0xFFFD] = 0x42;
+	mem[0x2FFC] = CPU::INS_BIT_ZP;
+	mem[0x2FFD] = 0x42;
 	mem[0x0042] = 0b01000000;
 	constexpr s32 EXPECTED_CYCLES = 3;
 
@@ -793,11 +789,10 @@ TEST_F( M6502AndEorOraBitTests, TestBitAbsolute )
 	using namespace m6502;
 	cpu.Flag.V = cpu.Flag.N = false;
 	cpu.A = 0xCC;
-	mem[0xFFFC] = CPU::INS_BIT_ABS;
-	mem[0xFFFD] = 0x00;
-	mem[0xFFFE] = 0x80;
+	mem[0x2FFC] = CPU::INS_BIT_ABS;
+	mem[0x2FFD] = 0x00;
+	mem[0x2FFE] = 0x80;
 	mem[0x8000] = 0xCC;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 4;
 
 	//when:
@@ -817,11 +812,10 @@ TEST_F( M6502AndEorOraBitTests, TestBitAbsoluteResultZero )
 	using namespace m6502;
 	cpu.Flag.V = cpu.Flag.N = true;
 	cpu.A = 0xCC;
-	mem[0xFFFC] = CPU::INS_BIT_ABS;
-	mem[0xFFFD] = 0x00;
-	mem[0xFFFE] = 0x80;
+	mem[0x2FFC] = CPU::INS_BIT_ABS;
+	mem[0x2FFD] = 0x00;
+	mem[0x2FFE] = 0x80;
 	mem[0x8000] = 0x33;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 4;
 
 	//when:
@@ -841,11 +835,10 @@ TEST_F( M6502AndEorOraBitTests, TestBitAbsoluteResultZeroBit6And7Zero )
 	using namespace m6502;
 	cpu.Flag.V = cpu.Flag.N = false;
 	cpu.A = 0x33;
-	mem[0xFFFC] = CPU::INS_BIT_ABS;
-	mem[0xFFFD] = 0x00;
-	mem[0xFFFE] = 0x80;
+	mem[0x2FFC] = CPU::INS_BIT_ABS;
+	mem[0x2FFD] = 0x00;
+	mem[0x2FFE] = 0x80;
 	mem[0x8000] = 0xCC;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 4;
 
 	//when:
@@ -865,11 +858,10 @@ TEST_F( M6502AndEorOraBitTests, TestBitAbsoluteResultZeroBit6And7Mixed )
 	using namespace m6502;
 	cpu.Flag.V = true;
 	cpu.Flag.N = false;
-	mem[0xFFFC] = CPU::INS_BIT_ABS;
-	mem[0xFFFD] = 0x00;
-	mem[0xFFFE] = 0x80;
+	mem[0x2FFC] = CPU::INS_BIT_ABS;
+	mem[0x2FFD] = 0x00;
+	mem[0x2FFE] = 0x80;
 	mem[0x8000] = 0b10000000;
-	CPU CPUCopy = cpu;
 	constexpr s32 EXPECTED_CYCLES = 4;
 
 	//when:

--- a/6502/6502Test/src/6502AddWithCarryTests.cpp
+++ b/6502/6502Test/src/6502AddWithCarryTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -51,7 +53,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.A = Test.A;
 		cpu.Flag.Z = !Test.ExpectZ;
@@ -89,7 +90,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.X = 0x10;
 		cpu.A = Test.A;
@@ -128,7 +128,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.Y = 0x10;
 		cpu.A = Test.A;
@@ -167,7 +166,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.A = Test.A;
 		cpu.Flag.Z = !Test.ExpectZ;
@@ -203,7 +201,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.A = Test.A;
 		cpu.Flag.Z = !Test.ExpectZ;
@@ -240,7 +237,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.X = 0x10;
 		cpu.A = Test.A;
@@ -278,7 +274,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.X = 0x04;
 		cpu.A = Test.A;
@@ -318,7 +313,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = Test.Carry;
 		cpu.Y = 0x04;
 		cpu.A = Test.A;

--- a/6502/6502Test/src/6502BranchTests.cpp
+++ b/6502/6502Test/src/6502BranchTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -21,7 +23,6 @@ TEST_F( M6502BranchTests, BEQCanBranchForwardsWhenZeroIsSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	mem[0xFF00] = CPU::INS_BEQ;
 	mem[0xFF01] = 0x1;
@@ -41,7 +42,6 @@ TEST_F( M6502BranchTests, BEQDoesNotBranchForwardsWhenZeroIsNotSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = false;
 	mem[0xFF00] = CPU::INS_BEQ;
 	mem[0xFF01] = 0x1;
@@ -61,9 +61,12 @@ TEST_F( M6502BranchTests, BEQCanBranchForwardsIntoANewPageWhenZeroIsSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFEFD, mem );
-	cpu.Flag.Z = true;
-	mem[0xFEFD] = CPU::INS_BEQ;
+    mem[0xFFFC] = 0xFD;
+    mem[0xFFFD] = 0xFE;
+    cpu.Reset( mem );
+
+    cpu.Flag.Z = true;
+    mem[0xFEFD] = CPU::INS_BEQ;
 	mem[0xFEFE] = 0x1;
 	constexpr s32 EXPECTED_CYCLES = 4;
 	CPU CPUCopy = cpu;
@@ -81,10 +84,10 @@ TEST_F( M6502BranchTests, BEQCanBranchBackwardsWhenZeroIsSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFFCC, mem );
+
 	cpu.Flag.Z = true;
-	mem[0xFFCC] = CPU::INS_BEQ;
-	mem[0xFFCD] = static_cast<Byte>( -0x2 );
+	mem[0xFF00] = CPU::INS_BEQ;
+	mem[0xFF01] = static_cast<Byte>( -0x2 );
 	constexpr s32 EXPECTED_CYCLES = 3;
 	CPU CPUCopy = cpu;
 
@@ -93,7 +96,7 @@ TEST_F( M6502BranchTests, BEQCanBranchBackwardsWhenZeroIsSet )
 
 	// then:
 	EXPECT_EQ( ActualCycles, EXPECTED_CYCLES );
-	EXPECT_EQ( cpu.PC, 0xFFCC );
+	EXPECT_EQ( cpu.PC, 0xFF00 );
 	EXPECT_EQ( cpu.PS, CPUCopy.PS );
 }
 
@@ -101,17 +104,16 @@ TEST_F( M6502BranchTests, BEQCanBranchBackwardsWhenZeroIsSetFromAssembleCode )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFFCC, mem );
 	cpu.Flag.Z = true;
 	/*
 	loop
 	lda #0
 	beq loop
 	*/
-	mem[0xFFCC] = 0xA9;
-	mem[0xFFCC+1] = 0x00;
-	mem[0xFFCC+2] = 0xF0;
-	mem[0xFFCC+3] = 0xFC;
+	mem[0xFF00] = 0xA9;
+	mem[0xFF00+1] = 0x00;
+	mem[0xFF00+2] = 0xF0;
+	mem[0xFF00+3] = 0xFC;
 	constexpr s32 EXPECTED_CYCLES = 2 + 3;
 	CPU CPUCopy = cpu;
 
@@ -120,7 +122,7 @@ TEST_F( M6502BranchTests, BEQCanBranchBackwardsWhenZeroIsSetFromAssembleCode )
 
 	// then:
 	EXPECT_EQ( ActualCycles, EXPECTED_CYCLES );
-	EXPECT_EQ( cpu.PC, 0xFFCC );
+	EXPECT_EQ( cpu.PC, 0xFF00 );
 	EXPECT_EQ( cpu.PS, CPUCopy.PS );
 }
 
@@ -128,7 +130,6 @@ TEST_F( M6502BranchTests, BNECanBranchForwardsWhenZeroIsNotSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = false;
 	mem[0xFF00] = CPU::INS_BNE;
 	mem[0xFF01] = 0x1;
@@ -149,7 +150,6 @@ TEST_F( M6502BranchTests, BCSCanBranchForwardsWhenCarryFlagIsSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	mem[0xFF00] = CPU::INS_BCS;
 	mem[0xFF01] = 0x1;
@@ -169,7 +169,6 @@ TEST_F( M6502BranchTests, BCCCanBranchForwardsWhenCarryFlagIsNotSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	mem[0xFF00] = CPU::INS_BCC;
 	mem[0xFF01] = 0x1;
@@ -189,7 +188,6 @@ TEST_F( M6502BranchTests, BMICanBranchForwardsWhenNegativeFlagIsSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.N = true;
 	mem[0xFF00] = CPU::INS_BMI;
 	mem[0xFF01] = 0x1;
@@ -209,7 +207,6 @@ TEST_F( M6502BranchTests, BPLCanBranchForwardsWhenCarryNegativeIsNotSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.N = false;
 	mem[0xFF00] = CPU::INS_BPL;
 	mem[0xFF01] = 0x1;
@@ -229,7 +226,6 @@ TEST_F( M6502BranchTests, BVSCanBranchForwardsWhenOverflowFlagIsSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.V = true;
 	mem[0xFF00] = CPU::INS_BVS;
 	mem[0xFF01] = 0x1;
@@ -249,7 +245,6 @@ TEST_F( M6502BranchTests, BVCCanBranchForwardsWhenOverflowNegativeIsNotSet )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.V = false;
 	mem[0xFF00] = CPU::INS_BVC;
 	mem[0xFF01] = 0x1;

--- a/6502/6502Test/src/6502CompareRegisterTests.cpp
+++ b/6502/6502Test/src/6502CompareRegisterTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -87,14 +89,17 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
-		Byte* Register = &cpu.A;
-		Byte Opcode = CPU::INS_CMP;
+		Byte* Register;
+		Byte Opcode;
 		switch ( RegisterToCompare )
 		{
+		case ERegister::A:
+		    Register =  &cpu.A;
+		    Opcode = CPU::INS_CMP;
+		    break;
 		case ERegister::X:
 			Register = &cpu.X;
 			Opcode = CPU::INS_CPX;
@@ -103,7 +108,7 @@ public:
 			Register = &cpu.Y;
 			Opcode = CPU::INS_CPY;
 			break;
-		};
+		}
 		*Register = Test.RegisterValue;
 
 		mem[0xFF00] = Opcode;
@@ -127,16 +132,19 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
 		
-		Byte* Register = &cpu.A;
-		Byte Opcode = CPU::INS_CMP_ZP;
+		Byte* Register;
+		Byte Opcode;
 		switch ( RegisterToCompare )
 		{
-		case ERegister::X:
+		case ERegister::A:
+            Register = &cpu.A;
+            Opcode = CPU::INS_CMP_ZP;
+            break;
+        case ERegister::X:
 			Register = &cpu.X;
 			Opcode = CPU::INS_CPX_ZP;
 			break;
@@ -144,7 +152,7 @@ public:
 			Register = &cpu.Y;
 			Opcode = CPU::INS_CPY_ZP;
 			break;
-		};
+		}
 		*Register = Test.RegisterValue;
 		mem[0xFF00] = Opcode;
 		mem[0xFF01] = 0x42;
@@ -168,7 +176,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
@@ -197,15 +204,18 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
 
-		Byte* Register = &cpu.A;
-		Byte Opcode = CPU::INS_CMP_ABS;
+		Byte* Register;
+		Byte Opcode;
 		switch ( RegisterToCompare )
 		{
+		case ERegister::A:
+            Register = &cpu.A;
+            Opcode = CPU::INS_CMP_ABS;
+		    break;
 		case ERegister::X:
 			Register = &cpu.X;
 			Opcode = CPU::INS_CPX_ABS;
@@ -214,7 +224,7 @@ public:
 			Register = &cpu.Y;
 			Opcode = CPU::INS_CPY_ABS;
 			break;
-		};
+		}
 		*Register = Test.RegisterValue;
 
 		mem[0xFF00] = Opcode;
@@ -240,7 +250,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
@@ -270,7 +279,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
@@ -300,7 +308,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;
@@ -331,7 +338,6 @@ public:
 	{
 		// given:
 		using namespace m6502;
-		cpu.Reset( 0xFF00, mem );
 		cpu.Flag.C = !Test.ExpectC;
 		cpu.Flag.Z = !Test.ExpectZ;
 		cpu.Flag.N = !Test.ExpectN;

--- a/6502/6502Test/src/6502IncrementDecrementTests.cpp
+++ b/6502/6502Test/src/6502IncrementDecrementTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -30,7 +32,6 @@ TEST_F( M6502IncrementDecrementTests, INXCanIncrementAZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0x0;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -53,7 +54,6 @@ TEST_F( M6502IncrementDecrementTests, INXCanIncrement255 )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0xFF;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -76,7 +76,6 @@ TEST_F( M6502IncrementDecrementTests, INXCanIncrementANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0b10001000;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -100,7 +99,6 @@ TEST_F( M6502IncrementDecrementTests, INYCanIncrementAZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0x0;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -123,7 +121,6 @@ TEST_F( M6502IncrementDecrementTests, INYCanIncrement255 )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0xFF;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -146,7 +143,6 @@ TEST_F( M6502IncrementDecrementTests, INYCanIncrementANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0b10001000;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -170,7 +166,6 @@ TEST_F( M6502IncrementDecrementTests, DEYCanDecementAZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0x0;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -193,7 +188,6 @@ TEST_F( M6502IncrementDecrementTests, DEYCanDecrement255 )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0xFF;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -216,7 +210,6 @@ TEST_F( M6502IncrementDecrementTests, DEYCanDecrementANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0b10001001;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -239,7 +232,6 @@ TEST_F( M6502IncrementDecrementTests, DEXCanDecementAZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0x0;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -262,7 +254,6 @@ TEST_F( M6502IncrementDecrementTests, DEXCanDecrement255 )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0xFF;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -285,7 +276,6 @@ TEST_F( M6502IncrementDecrementTests, DEXCanDecrementANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0b10001001;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -308,7 +298,6 @@ TEST_F( M6502IncrementDecrementTests, DECCanDecrementAValueInTheZeroPage )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	mem[0xFF00] = CPU::INS_DEC_ZP;
@@ -332,7 +321,6 @@ TEST_F( M6502IncrementDecrementTests, DECCanDecrementAValueInTheZeroPageX )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.X = 0x10;
@@ -357,7 +345,6 @@ TEST_F( M6502IncrementDecrementTests, DECCanDecrementAValueAbsolute )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	mem[0xFF00] = CPU::INS_DEC_ABS;
@@ -382,7 +369,6 @@ TEST_F( M6502IncrementDecrementTests, DECCanDecrementAValueAbsoluteX )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.X = 0x10;
@@ -408,7 +394,6 @@ TEST_F( M6502IncrementDecrementTests, INCCanIncrementAValueInTheZeroPage )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	mem[0xFF00] = CPU::INS_INC_ZP;
@@ -432,7 +417,6 @@ TEST_F( M6502IncrementDecrementTests, INCCanIncrementAValueInTheZeroPageX )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.X = 0x10;
@@ -457,7 +441,6 @@ TEST_F( M6502IncrementDecrementTests, INCCanIncrementAValueAbsolute )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	mem[0xFF00] = CPU::INS_INC_ABS;
@@ -482,7 +465,6 @@ TEST_F( M6502IncrementDecrementTests, INCCanIncrementAValueAbsoluteX )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.X = 0x10;
@@ -523,11 +505,11 @@ TEST_F( M6502IncrementDecrementTests, TestLoadAProgramThatCanIncMemory )
 	jmp start
 	*/
 	Byte TestPrg[] = 
-		{ 0x0,0x10,0xA9,0x00,0x85,0x42,0xE6,0x42,
+		{ 0xA9,0x00,0x85,0x42,0xE6,0x42,
 		0xA6,0x42,0xE8,0x4C,0x04,0x10 };
 
-	Word StartAddress = cpu.LoadPrg( TestPrg, sizeof(TestPrg), mem );
-	cpu.PC = StartAddress;
+	cpu.LoadPrg( 0x1000, TestPrg, sizeof(TestPrg), mem );
+	cpu.Reset( mem );
 
 	//then:
 	for ( m6502::s32 Clock = 1000; Clock > 0; )

--- a/6502/6502Test/src/6502JumpsAndCallsTests.cpp
+++ b/6502/6502Test/src/6502JumpsAndCallsTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -21,7 +23,6 @@ TEST_F( M6502JumpsAndCallsTests, CanJumpToASubroutineAndJumpBackAgain )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_JSR;
 	mem[0xFF01] = 0x00;
 	mem[0xFF02] = 0x80;
@@ -44,7 +45,6 @@ TEST_F( M6502JumpsAndCallsTests, JSRDoesNotAffectTheProcessorStatus )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_JSR;
 	mem[0xFF01] = 0x00;
 	mem[0xFF02] = 0x80;
@@ -65,7 +65,6 @@ TEST_F( M6502JumpsAndCallsTests, RTSDoesNotAffectTheProcessorStatus )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_JSR;
 	mem[0xFF01] = 0x00;
 	mem[0xFF02] = 0x80;
@@ -86,7 +85,6 @@ TEST_F( M6502JumpsAndCallsTests, JumpAbsoluteCanJumpToAnNewLocationInTheProgram 
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_JMP_ABS;
 	mem[0xFF01] = 0x00;
 	mem[0xFF02] = 0x80;
@@ -107,7 +105,6 @@ TEST_F( M6502JumpsAndCallsTests, JumpIndirectCanJumpToAnNewLocationInTheProgram 
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_JMP_IND;
 	mem[0xFF01] = 0x00;
 	mem[0xFF02] = 0x80;

--- a/6502/6502Test/src/6502LoadPrgTests.cpp
+++ b/6502/6502Test/src/6502LoadPrgTests.cpp
@@ -16,7 +16,7 @@ jmp start
 
 */
 static m6502::Byte TestPrg[] = {
-	0x00, 0x10, 0xA9, 0xFF, 0x85, 0x90,
+	0xA9, 0xFF, 0x85, 0x90,
 	0x8D, 0x00, 0x80, 0x49, 0xCC, 0x4C, 0x02, 0x10 };
 
 static const m6502::u32 NumBytesInPrg = 14;
@@ -29,7 +29,6 @@ public:
 
 	virtual void SetUp()
 	{
-		cpu.Reset( mem );
 	}
 
 	virtual void TearDown()
@@ -43,7 +42,7 @@ TEST_F( M6502LoadPrgTests, TestLoadProgramAProgramIntoTheCorrectAreaOfMemory )
 	using namespace m6502;
 
 	// when:
-	cpu.LoadPrg( TestPrg, NumBytesInPrg, mem );
+	cpu.LoadPrg( 0x1000, TestPrg, NumBytesInPrg, mem );
 
 	//then:
 	EXPECT_EQ( mem[0x0FFF], 0x0 );
@@ -63,8 +62,8 @@ TEST_F( M6502LoadPrgTests, TestLoadProgramAProgramAndExecuteIt )
 	using namespace m6502;
 
 	// when:
-	Word StartAddress = cpu.LoadPrg( TestPrg, NumBytesInPrg, mem );
-	cpu.PC = StartAddress;
+	cpu.LoadPrg( 0x1000, TestPrg, NumBytesInPrg, mem );
+	cpu.Reset( mem );
 
 	//then:
 	for ( m6502::s32 Clock = 1000; Clock > 0; )

--- a/6502/6502Test/src/6502LoadRegisterTests.cpp
+++ b/6502/6502Test/src/6502LoadRegisterTests.cpp
@@ -9,7 +9,9 @@ public:
 
 	virtual void SetUp()
 	{
-		cpu.Reset( mem );
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
+        cpu.Reset( mem );
 	}
 
 	virtual void TearDown()
@@ -81,9 +83,8 @@ TEST_F( M6502LoadRegisterTests, CPUCanExecuteMoreCyclesThanRequestedIfRequiredBy
 {
 	// given:
 	using namespace m6502;
-	mem[0xFFFC] = CPU::INS_LDA_IM;
-	mem[0xFFFD] = 0x84;
-	CPU CPUCopy = cpu;
+	mem[0xFF00] = CPU::INS_LDA_IM;
+	mem[0xFF01] = 0x84;
 	constexpr s32 NUM_CYCLES = 1;
 
 	//when:
@@ -99,8 +100,8 @@ void M6502LoadRegisterTests::TestLoadRegisterImmediate(
 {
 	// given:
 	using namespace m6502;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x84;
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x84;
 
 	//when:
 	CPU CPUCopy = cpu;
@@ -138,8 +139,8 @@ void M6502LoadRegisterTests::TestLoadRegisterZeroPage(
 {
 	// given:
 	using namespace m6502;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x42;
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0x37;
 
 	//when:
@@ -177,8 +178,8 @@ TEST_F( M6502LoadRegisterTests, LDAImmediateCanAffectTheZeroFlag )
 	// given:
 	using namespace m6502;
 	cpu.A = 0x44;
-	mem[0xFFFC] = CPU::INS_LDA_IM;
-	mem[0xFFFD] = 0x0;
+	mem[0xFF00] = CPU::INS_LDA_IM;
+	mem[0xFF01] = 0x0;
 	CPU CPUCopy = cpu;
 
 	//when:
@@ -197,8 +198,8 @@ void M6502LoadRegisterTests::TestLoadRegisterZeroPageX(
 	// given:
 	using namespace m6502;
 	cpu.X = 5;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x42;
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x42;
 	mem[0x0047] = 0x37;
 	CPU CPUCopy = cpu;
 
@@ -220,8 +221,8 @@ void M6502LoadRegisterTests::TestLoadRegisterZeroPageY(
 	// given:
 	using namespace m6502;
 	cpu.Y = 5;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x42;
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x42;
 	mem[0x0047] = 0x37;
 	CPU CPUCopy = cpu;
 
@@ -259,8 +260,8 @@ TEST_F( M6502LoadRegisterTests, LDAZeroPageXCanLoadAValueIntoTheARegisterWhenItW
 	// given:
 	using namespace m6502;
 	cpu.X = 0xFF;
-	mem[0xFFFC] = CPU::INS_LDA_ZPX;
-	mem[0xFFFD] = 0x80;
+	mem[0xFF00] = CPU::INS_LDA_ZPX;
+	mem[0xFF01] = 0x80;
 	mem[0x007F] = 0x37;
 
 	//when:
@@ -282,9 +283,9 @@ void M6502LoadRegisterTests::TestLoadRegisterAbsolute(
 	// given:
 	cpu.Flag.Z = cpu.Flag.N = true;
 	using namespace m6502;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x80;
-	mem[0xFFFE] = 0x44;	//0x4480
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x80;
+	mem[0xFF02] = 0x44;	//0x4480
 	mem[0x4480] = 0x37;
 	constexpr s32 EXPECTED_CYCLES = 4;
 	CPU CPUCopy = cpu;
@@ -326,9 +327,9 @@ void M6502LoadRegisterTests::TestLoadRegisterAbsoluteX(
 	cpu.Flag.Z = cpu.Flag.N = true;
 	using namespace m6502;
 	cpu.X = 1;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x80;
-	mem[0xFFFE] = 0x44;	//0x4480
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x80;
+	mem[0xFF02] = 0x44;	//0x4480
 	mem[0x4481] = 0x37;
 	constexpr s32 EXPECTED_CYCLES = 4;
 	CPU CPUCopy = cpu;
@@ -352,9 +353,9 @@ void M6502LoadRegisterTests::TestLoadRegisterAbsoluteY(
 	using namespace m6502;
 	cpu.Flag.Z = cpu.Flag.N = true;
 	cpu.Y = 1;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0x80;
-	mem[0xFFFE] = 0x44;	//0x4480
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0x80;
+	mem[0xFF02] = 0x44;	//0x4480
 	mem[0x4481] = 0x37;
 	constexpr s32 EXPECTED_CYCLES = 4;
 	CPU CPUCopy = cpu;
@@ -395,9 +396,9 @@ void M6502LoadRegisterTests::TestLoadRegisterAbsoluteXWhenCrossingPage(
 	// given:
 	using namespace m6502;
 	cpu.X = 0x1;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0xFF;
-	mem[0xFFFE] = 0x44;	//0x44FF
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0xFF;
+	mem[0xFF02] = 0x44;	//0x44FF
 	mem[0x4500] = 0x37;	//0x44FF+0x1 crosses page boundary!
 	constexpr s32 EXPECTED_CYCLES = 5;
 	CPU CPUCopy = cpu;
@@ -438,9 +439,9 @@ void M6502LoadRegisterTests::TestLoadRegisterAbsoluteYWhenCrossingPage(
 	// given:
 	using namespace m6502;
 	cpu.Y = 0x1;
-	mem[0xFFFC] = OpcodeToTest;
-	mem[0xFFFD] = 0xFF;
-	mem[0xFFFE] = 0x44;	//0x44FF
+	mem[0xFF00] = OpcodeToTest;
+	mem[0xFF01] = 0xFF;
+	mem[0xFF02] = 0x44;	//0x44FF
 	mem[0x4500] = 0x37;	//0x44FF+0x1 crosses page boundary!
 	constexpr s32 EXPECTED_CYCLES = 5;
 	CPU CPUCopy = cpu;
@@ -474,8 +475,8 @@ TEST_F( M6502LoadRegisterTests, LDAIndirectXCanLoadAValueIntoTheARegister )
 	using namespace m6502;
 	cpu.Flag.Z = cpu.Flag.N = true;
 	cpu.X = 0x04;
-	mem[0xFFFC] = CPU::INS_LDA_INDX;
-	mem[0xFFFD] = 0x02;
+	mem[0xFF00] = CPU::INS_LDA_INDX;
+	mem[0xFF01] = 0x02;
 	mem[0x0006] = 0x00;	//0x2 + 0x4
 	mem[0x0007] = 0x80;	
 	mem[0x8000] = 0x37;
@@ -499,8 +500,8 @@ TEST_F( M6502LoadRegisterTests, LDAIndirectYCanLoadAValueIntoTheARegister )
 	using namespace m6502;
 	cpu.Flag.Z = cpu.Flag.N = true;
 	cpu.Y = 0x04;
-	mem[0xFFFC] = CPU::INS_LDA_INDY;
-	mem[0xFFFD] = 0x02;
+	mem[0xFF00] = CPU::INS_LDA_INDY;
+	mem[0xFF01] = 0x02;
 	mem[0x0002] = 0x00;	
 	mem[0x0003] = 0x80;
 	mem[0x8004] = 0x37;	//0x8000 + 0x4
@@ -523,8 +524,8 @@ TEST_F( M6502LoadRegisterTests, LDAIndirectYCanLoadAValueIntoTheARegisterWhenItC
 	// given:
 	using namespace m6502;
 	cpu.Y = 0x1;
-	mem[0xFFFC] = CPU::INS_LDA_INDY;
-	mem[0xFFFD] = 0x05;
+	mem[0xFF00] = CPU::INS_LDA_INDY;
+	mem[0xFF01] = 0x05;
 	mem[0x0005] = 0xFF;
 	mem[0x0006] = 0x80;
 	mem[0x8100] = 0x37;	//0x80FF + 0x1

--- a/6502/6502Test/src/6502ShiftsTests.cpp
+++ b/6502/6502Test/src/6502ShiftsTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -21,14 +23,12 @@ TEST_F( M6502ShiftsTests, ASLCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.A = 1;
 	mem[0xFF00] = CPU::INS_ASL;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -45,14 +45,12 @@ TEST_F( M6502ShiftsTests, ASLCanShiftANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
 	cpu.A = 0b11000010;
 	mem[0xFF00] = CPU::INS_ASL;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -69,7 +67,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -77,7 +74,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageCanShiftTheValueOfOne )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 1;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -94,7 +90,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageCanShiftANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -102,7 +97,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageCanShiftANegativeValue )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0b11000010;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -119,7 +113,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageXCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -128,7 +121,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageXCanShiftTheValueOfOne )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 1;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -145,7 +137,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageXCanShiftANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -154,7 +145,6 @@ TEST_F( M6502ShiftsTests, ASLZeroPageXCanShiftANegativeValue )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 0b11000010;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -171,7 +161,6 @@ TEST_F( M6502ShiftsTests, ASLAbsCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -180,7 +169,6 @@ TEST_F( M6502ShiftsTests, ASLAbsCanShiftTheValueOfOne )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 1;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -197,7 +185,6 @@ TEST_F( M6502ShiftsTests, ASLAbsCanShiftANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -206,7 +193,6 @@ TEST_F( M6502ShiftsTests, ASLAbsCanShiftANegativeValue )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0b11000010;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -223,7 +209,6 @@ TEST_F( M6502ShiftsTests, ASLAbsXCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -233,7 +218,6 @@ TEST_F( M6502ShiftsTests, ASLAbsXCanShiftTheValueOfOne )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 1;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -250,7 +234,6 @@ TEST_F( M6502ShiftsTests, ASLAbsXCanShiftANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -260,7 +243,6 @@ TEST_F( M6502ShiftsTests, ASLAbsXCanShiftANegativeValue )
 	mem[0xFF02] = 0x80;
 	mem[0x8000+0x10] = 0b11000010;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -277,14 +259,12 @@ TEST_F( M6502ShiftsTests, LSRCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
 	cpu.A = 1;
 	mem[0xFF00] = CPU::INS_LSR;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -301,14 +281,12 @@ TEST_F( M6502ShiftsTests, LSRCanShiftAZeroIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.A = 8;
 	mem[0xFF00] = CPU::INS_LSR;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -325,7 +303,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -333,7 +310,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageCanShiftTheValueOfOne )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 1;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -350,7 +326,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageCanShiftAZeroIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -358,7 +333,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageCanShiftAZeroIntoTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 8;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -375,7 +349,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageXCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -384,7 +357,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageXCanShiftTheValueOfOne )
 	mem[0xFF01] = 0x42;
 	mem[0x0042+ 0x10] = 1;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -401,7 +373,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageXCanShiftAZeroIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -410,7 +381,6 @@ TEST_F( M6502ShiftsTests, LSRZeroPageXCanShiftAZeroIntoTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042+ 0x10] = 8;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -427,7 +397,6 @@ TEST_F( M6502ShiftsTests, LSRAbsCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -436,7 +405,6 @@ TEST_F( M6502ShiftsTests, LSRAbsCanShiftTheValueOfOne )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 1;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -453,7 +421,6 @@ TEST_F( M6502ShiftsTests, LSRAbsCanShiftAZeroIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -462,7 +429,6 @@ TEST_F( M6502ShiftsTests, LSRAbsCanShiftAZeroIntoTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 8;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -479,7 +445,6 @@ TEST_F( M6502ShiftsTests, LSRAbsXCanShiftTheValueOfOne )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -489,7 +454,6 @@ TEST_F( M6502ShiftsTests, LSRAbsXCanShiftTheValueOfOne )
 	mem[0xFF02] = 0x80;
 	mem[0x8000+0x10] = 1;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -506,7 +470,6 @@ TEST_F( M6502ShiftsTests, LSRAbsXCanShiftAZeroIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -516,7 +479,6 @@ TEST_F( M6502ShiftsTests, LSRAbsXCanShiftAZeroIntoTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 8;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -535,14 +497,12 @@ TEST_F( M6502ShiftsTests, ROLCanShiftABitOutOfTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
 	cpu.A = 0;
 	mem[0xFF00] = CPU::INS_ROL;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -559,14 +519,12 @@ TEST_F( M6502ShiftsTests, ROLCanShiftABitIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
 	cpu.A = 0b10000000;
 	mem[0xFF00] = CPU::INS_ROL;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -583,14 +541,12 @@ TEST_F( M6502ShiftsTests, ROLCanShiftZeroWithNoCarry )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
 	cpu.A = 0;
 	mem[0xFF00] = CPU::INS_ROL;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -607,14 +563,12 @@ TEST_F( M6502ShiftsTests, ROLCanShiftAValueThatResultInANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
 	cpu.A = 0b01110011;
 	mem[0xFF00] = CPU::INS_ROL;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -633,7 +587,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftABitOutOfTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -641,7 +594,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftABitOutOfTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -658,7 +610,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftABitIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -666,7 +617,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftABitIntoTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0b10000000;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -683,7 +633,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftZeroWithNoCarry )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -691,7 +640,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftZeroWithNoCarry )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -708,7 +656,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftAValueThatResultInANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -716,7 +663,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageCanShiftAValueThatResultInANegativeValue )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0b01110011;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -735,7 +681,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftABitOutOfTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -744,7 +689,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftABitOutOfTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 0;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -761,7 +705,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftABitIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -770,7 +713,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftABitIntoTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042+0x10] = 0b10000000;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -787,7 +729,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftZeroWithNoCarry )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -796,7 +737,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftZeroWithNoCarry )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 0;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -813,7 +753,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftAValueThatResultInANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -822,7 +761,6 @@ TEST_F( M6502ShiftsTests, ROLZeroPageXCanShiftAValueThatResultInANegativeValue )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 0b01110011;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -841,7 +779,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftABitOutOfTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -850,7 +787,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftABitOutOfTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -867,7 +803,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftABitIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -876,7 +811,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftABitIntoTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0b10000000;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -893,7 +827,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftZeroWithNoCarry )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -902,7 +835,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftZeroWithNoCarry )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -919,7 +851,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftAValueThatResultInANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -928,7 +859,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteCanShiftAValueThatResultInANegativeValue )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0b01110011;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -947,7 +877,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftABitOutOfTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = true;
@@ -957,7 +886,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftABitOutOfTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000+0x10] = 0;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -974,7 +902,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftABitIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -984,7 +911,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftABitIntoTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 0b10000000;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1001,7 +927,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftZeroWithNoCarry )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
@@ -1011,7 +936,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftZeroWithNoCarry )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 0;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1028,7 +952,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftAValueThatResultInANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1038,7 +961,6 @@ TEST_F( M6502ShiftsTests, ROLAbsoluteXCanShiftAValueThatResultInANegativeValue )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 0b01110011;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1057,14 +979,12 @@ TEST_F( M6502ShiftsTests, RORCanShiftTheCarryFlagIntoTheOperand )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
 	cpu.A = 0;
 	mem[0xFF00] = CPU::INS_ROR;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1081,14 +1001,12 @@ TEST_F( M6502ShiftsTests, RORCanShiftAValueIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
 	cpu.A = 1;
 	mem[0xFF00] = CPU::INS_ROR;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1105,14 +1023,12 @@ TEST_F( M6502ShiftsTests, RORCanRotateANumber )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
 	cpu.A = 0b01101101;
 	mem[0xFF00] = CPU::INS_ROR;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1131,7 +1047,6 @@ TEST_F( M6502ShiftsTests, RORZeroPageCanShiftTheCarryFlagIntoTheOperand )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1139,7 +1054,6 @@ TEST_F( M6502ShiftsTests, RORZeroPageCanShiftTheCarryFlagIntoTheOperand )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1156,7 +1070,6 @@ TEST_F( M6502ShiftsTests, RORZeroPageCanShiftAValueIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1164,7 +1077,6 @@ TEST_F( M6502ShiftsTests, RORZeroPageCanShiftAValueIntoTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 1;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1181,7 +1093,6 @@ TEST_F( M6502ShiftsTests, RORZeroPageCanRotateANumber )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -1189,7 +1100,6 @@ TEST_F( M6502ShiftsTests, RORZeroPageCanRotateANumber )
 	mem[0xFF01] = 0x42;
 	mem[0x0042] = 0b01101101;
 	constexpr s32 EXPECTED_CYCLES = 5;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1208,7 +1118,6 @@ TEST_F( M6502ShiftsTests, RORZeroXPageCanShiftTheCarryFlagIntoTheOperand )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1217,7 +1126,6 @@ TEST_F( M6502ShiftsTests, RORZeroXPageCanShiftTheCarryFlagIntoTheOperand )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 0;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1234,7 +1142,6 @@ TEST_F( M6502ShiftsTests, RORZeroXPageCanShiftAValueIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1243,7 +1150,6 @@ TEST_F( M6502ShiftsTests, RORZeroXPageCanShiftAValueIntoTheCarryFlag )
 	mem[0xFF01] = 0x42;
 	mem[0x0042+0x10] = 1;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1260,7 +1166,6 @@ TEST_F( M6502ShiftsTests, RORZeroXPageCanRotateANumber )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -1269,7 +1174,6 @@ TEST_F( M6502ShiftsTests, RORZeroXPageCanRotateANumber )
 	mem[0xFF01] = 0x42;
 	mem[0x0042 + 0x10] = 0b01101101;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1288,7 +1192,6 @@ TEST_F( M6502ShiftsTests, RORAbsolutePageCanShiftTheCarryFlagIntoTheOperand )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1297,7 +1200,6 @@ TEST_F( M6502ShiftsTests, RORAbsolutePageCanShiftTheCarryFlagIntoTheOperand )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1314,7 +1216,6 @@ TEST_F( M6502ShiftsTests, RORAbsolutePageCanShiftAValueIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1323,7 +1224,6 @@ TEST_F( M6502ShiftsTests, RORAbsolutePageCanShiftAValueIntoTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 1;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1340,7 +1240,6 @@ TEST_F( M6502ShiftsTests, RORAbsolutePageCanRotateANumber )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -1349,7 +1248,6 @@ TEST_F( M6502ShiftsTests, RORAbsolutePageCanRotateANumber )
 	mem[0xFF02] = 0x80;
 	mem[0x8000] = 0b01101101;
 	constexpr s32 EXPECTED_CYCLES = 6;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1368,7 +1266,6 @@ TEST_F( M6502ShiftsTests, RORAbsoluteXPageCanShiftTheCarryFlagIntoTheOperand )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1378,7 +1275,6 @@ TEST_F( M6502ShiftsTests, RORAbsoluteXPageCanShiftTheCarryFlagIntoTheOperand )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 0;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1395,7 +1291,6 @@ TEST_F( M6502ShiftsTests, RORAbsoluteXPageCanShiftAValueIntoTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	cpu.Flag.Z = false;
 	cpu.Flag.N = false;
@@ -1405,7 +1300,6 @@ TEST_F( M6502ShiftsTests, RORAbsoluteXPageCanShiftAValueIntoTheCarryFlag )
 	mem[0xFF02] = 0x80;
 	mem[0x8000+0x10] = 1;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -1422,7 +1316,6 @@ TEST_F( M6502ShiftsTests, RORAbsoluteXPageCanRotateANumber )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	cpu.Flag.Z = true;
 	cpu.Flag.N = false;
@@ -1432,7 +1325,6 @@ TEST_F( M6502ShiftsTests, RORAbsoluteXPageCanRotateANumber )
 	mem[0xFF02] = 0x80;
 	mem[0x8000 + 0x10] = 0b01101101;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );

--- a/6502/6502Test/src/6502StackOperationsTests.cpp
+++ b/6502/6502Test/src/6502StackOperationsTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -21,13 +23,11 @@ TEST_F( M6502StackOperationsTests, TSXCanTransferTheStackPointerToXRegister )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = cpu.Flag.N = true;
 	cpu.X = 0x00;
 	cpu.SP = 0x01;
 	mem[0xFF00] = CPU::INS_TSX;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -43,13 +43,11 @@ TEST_F( M6502StackOperationsTests, TSXCanTransferAZeroStackPointerToXRegister )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = cpu.Flag.N = true;
 	cpu.X = 0x00;
 	cpu.SP = 0x00;
 	mem[0xFF00] = CPU::INS_TSX;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -65,13 +63,11 @@ TEST_F( M6502StackOperationsTests, TSXCanTransferANegativeStackPointerToXRegiste
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = cpu.Flag.N = false;
 	cpu.X = 0x00;
 	cpu.SP = 0b10000000;
 	mem[0xFF00] = CPU::INS_TSX;
 	constexpr s32 EXPECTED_CYCLES = 2;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -87,7 +83,6 @@ TEST_F( M6502StackOperationsTests, TXSCanTransferXRegisterToTheStackPointer )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0xFF;
 	cpu.SP = 0;
 	mem[0xFF00] = CPU::INS_TXS;
@@ -107,7 +102,6 @@ TEST_F( M6502StackOperationsTests, PHACanPushARegsiterOntoTheStack )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0x42;
 	mem[0xFF00] = CPU::INS_PHA;
 	constexpr s32 EXPECTED_CYCLES = 3;
@@ -127,13 +121,11 @@ TEST_F( M6502StackOperationsTests, PLACanPullAValueFromTheStackIntoTheARegsiter 
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0x00;
 	cpu.SP = 0xFE;
 	mem[0x01FF] = 0x42;
 	mem[0xFF00] = CPU::INS_PLA;
 	constexpr s32 EXPECTED_CYCLES = 4;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -148,7 +140,6 @@ TEST_F( M6502StackOperationsTests, PLACanPullAZeroValueFromTheStackIntoTheARegsi
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.Z = false;
 	cpu.Flag.N = true;
 	cpu.A = 0x42;
@@ -156,7 +147,6 @@ TEST_F( M6502StackOperationsTests, PLACanPullAZeroValueFromTheStackIntoTheARegsi
 	mem[0x01FF] = 0x00;
 	mem[0xFF00] = CPU::INS_PLA;
 	constexpr s32 EXPECTED_CYCLES = 4;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -173,7 +163,6 @@ TEST_F( M6502StackOperationsTests, PLACanPullANegativeValueFromTheStackIntoTheAR
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.N = false;
 	cpu.Flag.Z = true;
 	cpu.A = 0x42;
@@ -181,7 +170,6 @@ TEST_F( M6502StackOperationsTests, PLACanPullANegativeValueFromTheStackIntoTheAR
 	mem[0x01FF] = 0b10000001;
 	mem[0xFF00] = CPU::INS_PLA;
 	constexpr s32 EXPECTED_CYCLES = 4;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -198,7 +186,6 @@ TEST_F( M6502StackOperationsTests, PHPCanPushProcessorStatusOntoTheStack )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.PS = 0xCC;
 	mem[0xFF00] = CPU::INS_PHP;
 	constexpr s32 EXPECTED_CYCLES = 3;
@@ -219,11 +206,9 @@ TEST_F( M6502StackOperationsTests, PHPAlwaysSetsBits4And5OnTheStack )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.PS = 0x0;
 	mem[0xFF00] = CPU::INS_PHP;
 	constexpr s32 EXPECTED_CYCLES = 3;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -247,13 +232,11 @@ TEST_F( M6502StackOperationsTests, PLPCanPullAValueFromTheStackIntoTheProcessorS
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.SP = 0xFE;
 	cpu.PS = 0;
 	mem[0x01FF] = 0x42 | CPU::BreakFlagBit | CPU::UnusedFlagBit;
 	mem[0xFF00] = CPU::INS_PLP;
 	constexpr s32 EXPECTED_CYCLES = 4;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -267,13 +250,11 @@ TEST_F( M6502StackOperationsTests, PLPClearsBits4And5WhenPullingFromTheStack )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.SP = 0xFE;
 	cpu.PS = 0;
 	mem[0x01FF] = CPU::BreakFlagBit | CPU::UnusedFlagBit;
 	mem[0xFF00] = CPU::INS_PLP;
 	constexpr s32 EXPECTED_CYCLES = 4;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );

--- a/6502/6502Test/src/6502StatusFlagChangeTests.cpp
+++ b/6502/6502Test/src/6502StatusFlagChangeTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -21,7 +23,6 @@ TEST_F( M6502StatusFlagChangeTests, CLCWillClearTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = true;
 	mem[0xFF00] = CPU::INS_CLC;
 	constexpr s32 EXPECTED_CYCLES = 2;
@@ -45,7 +46,6 @@ TEST_F( M6502StatusFlagChangeTests, SECWillSetTheCarryFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.C = false;
 	mem[0xFF00] = CPU::INS_SEC;
 	constexpr s32 EXPECTED_CYCLES = 2;
@@ -69,7 +69,6 @@ TEST_F( M6502StatusFlagChangeTests, CLDWillClearTheDecimalFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.D = true;
 	mem[0xFF00] = CPU::INS_CLD;
 	constexpr s32 EXPECTED_CYCLES = 2;
@@ -93,7 +92,6 @@ TEST_F( M6502StatusFlagChangeTests, SEDWillSetTheDecimalFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.D = false;
 	mem[0xFF00] = CPU::INS_SED;
 	constexpr s32 EXPECTED_CYCLES = 2;
@@ -117,7 +115,6 @@ TEST_F( M6502StatusFlagChangeTests, CLIWillClearTheInterruptFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.I = true;
 	mem[0xFF00] = CPU::INS_CLI;
 	constexpr s32 EXPECTED_CYCLES = 2;
@@ -141,7 +138,6 @@ TEST_F( M6502StatusFlagChangeTests, SEIWillSetTheInterruptFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.I = false;
 	mem[0xFF00] = CPU::INS_SEI;
 	constexpr s32 EXPECTED_CYCLES = 2;
@@ -165,7 +161,6 @@ TEST_F( M6502StatusFlagChangeTests, CLVWillClearTheOverflowFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.V = true;
 	mem[0xFF00] = CPU::INS_CLV;
 	constexpr s32 EXPECTED_CYCLES = 2;

--- a/6502/6502Test/src/6502StoreRegisterTests.cpp
+++ b/6502/6502Test/src/6502StoreRegisterTests.cpp
@@ -22,6 +22,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0xFC;
+        mem[0xFFFD] = 0x2F;
 		cpu.Reset( mem );
 	}
 
@@ -36,8 +38,8 @@ public:
 		// given:
 		using namespace m6502;
 		cpu.*Register = 0x2F;
-		mem[0xFFFC] = OpcodeToTest;
-		mem[0xFFFD] = 0x80;
+		mem[0x2FFC] = OpcodeToTest;
+		mem[0x2FFD] = 0x80;
 		mem[0x0080] = 0x00;
 		constexpr s32 EXPECTED_CYCLES = 3;
 		CPU CPUCopy = cpu;
@@ -58,9 +60,9 @@ public:
 		// given:
 		using namespace m6502;
 		cpu.*Register = 0x2F;
-		mem[0xFFFC] = OpcodeToTest;
-		mem[0xFFFD] = 0x00;
-		mem[0xFFFE] = 0x80;
+		mem[0x2FFC] = OpcodeToTest;
+		mem[0x2FFD] = 0x00;
+		mem[0x2FFE] = 0x80;
 		mem[0x8000] = 0x00;
 		constexpr s32 EXPECTED_CYCLES = 4;
 		CPU CPUCopy = cpu;
@@ -82,8 +84,8 @@ public:
 		using namespace m6502;
 		cpu.*Register = 0x42;
 		cpu.X = 0x0F;
-		mem[0xFFFC] = OpcodeToTest;
-		mem[0xFFFD] = 0x80;
+		mem[0x2FFC] = OpcodeToTest;
+		mem[0x2FFD] = 0x80;
 		mem[0x008F] = 0x00;
 		constexpr s32 EXPECTED_CYCLES = 4;
 		CPU CPUCopy = cpu;
@@ -105,8 +107,8 @@ public:
 		using namespace m6502;
 		cpu.*Register = 0x42;
 		cpu.Y = 0x0F;
-		mem[0xFFFC] = OpcodeToTest;
-		mem[0xFFFD] = 0x80;
+		mem[0x2FFC] = OpcodeToTest;
+		mem[0x2FFD] = 0x80;
 		mem[0x008F] = 0x00;
 		constexpr s32 EXPECTED_CYCLES = 4;
 		CPU CPUCopy = cpu;
@@ -181,9 +183,9 @@ TEST_F( M6502StoreRegisterTests, STAAbsoluteXCanStoreTheARegisterIntoMemory )
 	using namespace m6502;
 	cpu.A = 0x42;
 	cpu.X = 0x0F;
-	mem[0xFFFC] = CPU::INS_STA_ABSX;
-	mem[0xFFFD] = 0x00;
-	mem[0xFFFE] = 0x80;
+	mem[0x2FFC] = CPU::INS_STA_ABSX;
+	mem[0x2FFD] = 0x00;
+	mem[0x2FFE] = 0x80;
 	constexpr s32 EXPECTED_CYCLES = 5;
 	CPU CPUCopy = cpu;
 
@@ -202,9 +204,9 @@ TEST_F( M6502StoreRegisterTests, STAAbsoluteYCanStoreTheARegisterIntoMemory )
 	using namespace m6502;
 	cpu.A = 0x42;
 	cpu.Y = 0x0F;
-	mem[0xFFFC] = CPU::INS_STA_ABSY;
-	mem[0xFFFD] = 0x00;
-	mem[0xFFFE] = 0x80;
+	mem[0x2FFC] = CPU::INS_STA_ABSY;
+	mem[0x2FFD] = 0x00;
+	mem[0x2FFE] = 0x80;
 	constexpr s32 EXPECTED_CYCLES = 5;
 	CPU CPUCopy = cpu;
 
@@ -223,8 +225,8 @@ TEST_F( M6502StoreRegisterTests, STAIndirectXCanStoreTheARegisterIntoMemory )
 	using namespace m6502;
 	cpu.A = 0x42;
 	cpu.X = 0x0F;
-	mem[0xFFFC] = CPU::INS_STA_INDX;
-	mem[0xFFFD] = 0x20;
+	mem[0x2FFC] = CPU::INS_STA_INDX;
+	mem[0x2FFD] = 0x20;
 	mem[0x002F] = 0x00;
 	mem[0x0030] = 0x80;
 	mem[0x8000] = 0x00;
@@ -246,8 +248,8 @@ TEST_F( M6502StoreRegisterTests, STAIndirectYCanStoreTheARegisterIntoMemory )
 	using namespace m6502;
 	cpu.A = 0x42;
 	cpu.Y = 0x0F;
-	mem[0xFFFC] = CPU::INS_STA_INDY;
-	mem[0xFFFD] = 0x20;
+	mem[0x2FFC] = CPU::INS_STA_INDY;
+	mem[0x2FFD] = 0x20;
 	mem[0x0020] = 0x00;
 	mem[0x0021] = 0x80;
 	mem[0x8000 + 0x0F] = 0x00;

--- a/6502/6502Test/src/6502SystemFunctionsTests.cpp
+++ b/6502/6502Test/src/6502SystemFunctionsTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -21,7 +23,6 @@ TEST_F( M6502SystemFunctionsTests, NOPWillDoNothingButConsumeACycle )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_NOP;
 	constexpr s32 EXPECTED_CYCLES = 2;
 	CPU CPUCopy = cpu;
@@ -43,12 +44,10 @@ TEST_F( M6502SystemFunctionsTests, BRKWillLoadTheProgramCounterFromTheInterruptV
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_BRK;
 	mem[0xFFFE] = 0x00;
 	mem[0xFFFF] = 0x80;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -62,12 +61,10 @@ TEST_F( M6502SystemFunctionsTests, BRKWillLoadTheProgramCounterFromTheInterruptV
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_BRK;
 	mem[0xFFFE] = 0x00;
 	mem[0xFFFF] = 0x90;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -81,11 +78,9 @@ TEST_F( M6502SystemFunctionsTests, BRKWillSetTheBreakFlag )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Flag.B = false;
 	mem[0xFF00] = CPU::INS_BRK;
 	constexpr s32 EXPECTED_CYCLES = 7;
-	CPU CPUCopy = cpu;
 
 	// when:
 	const s32 ActualCycles = cpu.Execute( EXPECTED_CYCLES, mem );
@@ -99,7 +94,6 @@ TEST_F( M6502SystemFunctionsTests, BRKWillPush3BytesOntoTheStack )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_BRK;
 	constexpr s32 EXPECTED_CYCLES = 7;
 	CPU CPUCopy = cpu;
@@ -116,7 +110,6 @@ TEST_F( M6502SystemFunctionsTests, BRKWillPushPCandPSOntoTheStack )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_BRK;
 	constexpr s32 EXPECTED_CYCLES = 7;
 	CPU CPUCopy = cpu;
@@ -148,7 +141,6 @@ TEST_F( M6502SystemFunctionsTests, RTICanReturnFromAnInterruptLeavingTheCPUInThe
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	mem[0xFF00] = CPU::INS_BRK;
 	mem[0xFFFE] = 0x00;
 	mem[0xFFFF] = 0x80;

--- a/6502/6502Test/src/6502TransferRegisterTests.cpp
+++ b/6502/6502Test/src/6502TransferRegisterTests.cpp
@@ -9,6 +9,8 @@ public:
 
 	virtual void SetUp()
 	{
+        mem[0xFFFC] = 0x00;
+        mem[0xFFFD] = 0xFF;
 		cpu.Reset( mem );
 	}
 
@@ -30,7 +32,6 @@ TEST_F( M6502TransferRegistgerTests, TAXCanTransferANonNegativeNonZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0x42;
 	cpu.X = 0x32;
 	cpu.Flag.Z = true;
@@ -55,7 +56,6 @@ TEST_F( M6502TransferRegistgerTests, TAXCanTransferANonNegativeZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0x0;
 	cpu.X = 0x32;
 	cpu.Flag.Z = false;
@@ -80,7 +80,6 @@ TEST_F( M6502TransferRegistgerTests, TAXCanTransferANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0b10001011;
 	cpu.X = 0x32;
 	cpu.Flag.Z = true;
@@ -105,7 +104,6 @@ TEST_F( M6502TransferRegistgerTests, TAYCanTransferANonNegativeNonZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0x42;
 	cpu.Y = 0x32;
 	cpu.Flag.Z = true;
@@ -130,7 +128,6 @@ TEST_F( M6502TransferRegistgerTests, TAYCanTransferANonNegativeZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0x0;
 	cpu.Y = 0x32;
 	cpu.Flag.Z = false;
@@ -155,7 +152,6 @@ TEST_F( M6502TransferRegistgerTests, TAYCanTransferANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.A = 0b10001011;
 	cpu.Y = 0x32;
 	cpu.Flag.Z = true;
@@ -180,7 +176,6 @@ TEST_F( M6502TransferRegistgerTests, TXACanTransferANonNegativeNonZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0x42;
 	cpu.A = 0x32;
 	cpu.Flag.Z = true;
@@ -205,7 +200,6 @@ TEST_F( M6502TransferRegistgerTests, TXACanTransferANonNegativeZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0x0;
 	cpu.A = 0x32;
 	cpu.Flag.Z = false;
@@ -230,7 +224,6 @@ TEST_F( M6502TransferRegistgerTests, TXACanTransferANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.X = 0b10001011;
 	cpu.A = 0x32;
 	cpu.Flag.Z = true;
@@ -255,7 +248,6 @@ TEST_F( M6502TransferRegistgerTests, TYACanTransferANonNegativeNonZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0x42;
 	cpu.A = 0x32;
 	cpu.Flag.Z = true;
@@ -280,7 +272,6 @@ TEST_F( M6502TransferRegistgerTests, TYACanTransferANonNegativeZeroValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0x0;
 	cpu.A = 0x32;
 	cpu.Flag.Z = false;
@@ -305,7 +296,6 @@ TEST_F( M6502TransferRegistgerTests, TYACanTransferANegativeValue )
 {
 	// given:
 	using namespace m6502;
-	cpu.Reset( 0xFF00, mem );
 	cpu.Y = 0b10001011;
 	cpu.A = 0x32;
 	cpu.Flag.Z = true;


### PR DESCRIPTION
Additionally; LoadPrg is given address to load into, rather than having address in the beginning of its array.

RESET vector is not the position in memory where the CPU starts executing, but it contains the address to where the CPU should jump to and start to execute.

Also, just like `NumBytes` is not in the `Program` array of bytes, neither should the `LoadAddress` be, so it is passed as an argument.